### PR TITLE
load intermediate table into memory

### DIFF
--- a/RoomDraw/app/helpers/search_helper.rb
+++ b/RoomDraw/app/helpers/search_helper.rb
@@ -6,8 +6,8 @@ module SearchHelper
     generator = CollectionDisplayService.new
 
     # for each collection, check if it satisfies all present conditions
-    Collection.find_each do |col|
-      collection = generator.retrieve col.id
+    Collection.includes(:rooms).find_each do |col|
+      collection = generator.retrieve col.rooms, col.id
       valid = true
       if conds.present?
         conds.each do |cond, value|

--- a/RoomDraw/app/helpers/search_helper.rb
+++ b/RoomDraw/app/helpers/search_helper.rb
@@ -7,7 +7,7 @@ module SearchHelper
 
     # for each collection, check if it satisfies all present conditions
     Collection.includes(:rooms).find_each do |col|
-      collection = generator.retrieve col.rooms, col.id
+      collection = generator.retrieve col.rooms
       valid = true
       if conds.present?
         conds.each do |cond, value|

--- a/RoomDraw/app/models/collection.rb
+++ b/RoomDraw/app/models/collection.rb
@@ -1,5 +1,5 @@
 class Collection < ActiveRecord::Base
   # constraints, also specifying foreign key to Active Record
-  has_many :rooms, foreign_key: [:dorm_name, :room_num]
+  has_many :rooms
   has_many :requests
 end

--- a/RoomDraw/app/services/collection_display_service.rb
+++ b/RoomDraw/app/services/collection_display_service.rb
@@ -3,12 +3,12 @@ class CollectionDisplayService
   def initialize
   end
 
-  def retrieve(rooms, col_id)
+  def retrieve(rooms)
     get_capacities rooms
     get_nums rooms
 
     return {
-      id: col_id,
+      id: rooms.first.collection_id,
       rooms: rooms,
       capacity: (total_capacity @caps),
       dorm_name: rooms.first[:dorm_name],

--- a/RoomDraw/app/services/collection_display_service.rb
+++ b/RoomDraw/app/services/collection_display_service.rb
@@ -3,17 +3,35 @@ class CollectionDisplayService
   def initialize
   end
 
-  def retrieve(col_id)
-    r = Room.where collection_id: col_id
-    {
+  def retrieve(rooms, col_id)
+    get_capacities rooms
+    get_nums rooms
+
+    return {
       id: col_id,
-      rooms: r,
-      capacity: (r.sum :capacity),
-      dorm_name: r.first[:dorm_name],
-      num_rooms: r.size,
-      room_nums: (r.pluck :room_num).sort,
-      room_capacities: (r.pluck :capacity).sort
+      rooms: rooms,
+      capacity: (total_capacity @caps),
+      dorm_name: rooms.first[:dorm_name],
+      num_rooms: rooms.length,
+      room_nums: @nums.sort,
+      room_capacities: @caps.sort
     }
+  end
+
+  def get_nums(rooms)
+    @nums = []
+    rooms.each{|r| @nums << r.room_num}
+    return @nums
+  end
+
+  def get_capacities(rooms)
+    @caps = []
+    rooms.each{|r| @caps << r.capacity}
+    return @caps
+  end
+
+  def total_capacity(caps)
+    caps.inject{|sum, x| sum + x}
   end
 
 end

--- a/RoomDraw/app/services/collection_display_service.rb
+++ b/RoomDraw/app/services/collection_display_service.rb
@@ -13,8 +13,8 @@ class CollectionDisplayService
       capacity: (total_capacity @caps),
       dorm_name: rooms.first[:dorm_name],
       num_rooms: rooms.length,
-      room_nums: @nums.sort,
-      room_capacities: @caps.sort
+      room_nums: @nums,
+      room_capacities: @caps
     }
   end
 

--- a/RoomDraw/app/views/queue/_pref.html.erb
+++ b/RoomDraw/app/views/queue/_pref.html.erb
@@ -1,4 +1,4 @@
-<% collection = CollectionDisplayService.new.retrieve request.collection_id %>
+<% collection = CollectionDisplayService.new.retrieve Collection.find(request.collection_id).rooms %>
 
 <tr>
   <td> <%= link_to "X", queue_path(req_id: request.id), :method =>

--- a/RoomDraw/db/schema.rb
+++ b/RoomDraw/db/schema.rb
@@ -13,87 +13,81 @@
 
 ActiveRecord::Schema.define(version: 20151030232612) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "collections", force: :cascade do |t|
-    t.integer  "suite_num",  limit: 4
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.integer  "suite_num"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "draw_groups", force: :cascade do |t|
-    t.integer  "student_id", limit: 4
-    t.decimal  "draw_num",             precision: 10, scale: 5
+    t.integer  "student_id"
+    t.decimal  "draw_num",   precision: 10, scale: 5
     t.boolean  "for_suite"
-    t.datetime "created_at",                                    null: false
-    t.datetime "updated_at",                                    null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
-  add_index "draw_groups", ["student_id"], name: "rep_id", using: :btree
-
   create_table "members", force: :cascade do |t|
-    t.integer  "draw_group_id", limit: 4
-    t.integer  "student_id",    limit: 4
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "draw_group_id"
+    t.integer  "student_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   add_index "members", ["draw_group_id", "student_id"], name: "index_members_on_draw_group_id_and_student_id", unique: true, using: :btree
-  add_index "members", ["student_id"], name: "student_id", using: :btree
 
   create_table "occupies", force: :cascade do |t|
-    t.integer  "student_id",    limit: 4
-    t.integer  "room_id",       limit: 4
-    t.string   "dorm_name",     limit: 255
-    t.string   "room_num",      limit: 255
-    t.integer  "academic_year", limit: 4
+    t.integer  "student_id"
+    t.integer  "room_id"
+    t.string   "dorm_name"
+    t.string   "room_num"
+    t.integer  "academic_year"
     t.boolean  "in_fall?"
     t.boolean  "in_spring?"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
-
-  add_index "occupies", ["room_id"], name: "fk_rails_95d84e3073", using: :btree
-  add_index "occupies", ["student_id"], name: "fk_rails_4a9d76a866", using: :btree
 
   create_table "requests", force: :cascade do |t|
-    t.integer  "draw_group_id", limit: 4
-    t.integer  "collection_id", limit: 4
-    t.decimal  "rank_absolute",           precision: 10
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.integer  "draw_group_id"
+    t.integer  "collection_id"
+    t.decimal  "rank_absolute"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
-  add_index "requests", ["collection_id"], name: "fk_rails_7d23987a4b", using: :btree
-  add_index "requests", ["draw_group_id"], name: "fk_rails_6a394ae907", using: :btree
   add_index "requests", ["rank_absolute"], name: "index_requests_on_rank_absolute", unique: true, using: :btree
 
   create_table "rooms", force: :cascade do |t|
-    t.string   "dorm_name",     limit: 255
-    t.string   "room_num",      limit: 255
-    t.integer  "capacity",      limit: 4
-    t.integer  "collection_id", limit: 4,   null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.string   "dorm_name"
+    t.string   "room_num"
+    t.integer  "capacity"
+    t.integer  "collection_id", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
-  add_index "rooms", ["collection_id"], name: "fk_rails_c704d37356", using: :btree
   add_index "rooms", ["dorm_name", "room_num"], name: "index_rooms_on_dorm_name_and_room_num", unique: true, using: :btree
 
   create_table "students", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.integer  "draw_num",   limit: 4
-    t.integer  "grad_year",  limit: 4
-    t.boolean  "is_absent",              default: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.string   "name"
+    t.integer  "draw_num"
+    t.integer  "grad_year"
+    t.boolean  "is_absent",  default: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
   end
 
   add_index "students", ["draw_num"], name: "index_students_on_draw_num", unique: true, using: :btree
 
   create_table "users", id: false, force: :cascade do |t|
-    t.string   "student_id",      limit: 255, null: false
-    t.string   "password_digest", limit: 255, null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.string   "student_id",      null: false
+    t.string   "password_digest", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   add_index "users", ["student_id"], name: "index_users_on_student_id", unique: true, using: :btree


### PR DESCRIPTION
Hey so, I made some of the changes I was talking about in the other PR. I think we can still cut down some of the load time.  Here are some one-off times I got from my computer:

Old Version:

```
Completed 200 OK in 24836ms (Views: 21701.5ms | ActiveRecord: 3132.5ms)
```

This Version

```
Completed 200 OK in 951ms (Views: 934.9ms | ActiveRecord: 15.0ms)
```

In this version, all the calculation is happening in the views, so it makes sense they'd take the longest.
This also suggests to me that 30 entries. is probably too long.

Let me know what you think.
We should talk about this more tomorrow.
